### PR TITLE
修复反引号包围的关键字导致的SQL解析错误问题

### DIFF
--- a/api/main2.py
+++ b/api/main2.py
@@ -5,6 +5,7 @@ import traceback
 
 from sqllineage.runner import LineageRunner
 from sqllineage.core.models import Table, Column
+from sql_utils import detect_and_set_dialect_for_backticks
 
 # --- 布局常量 (保持不变) ---
 NODE_BASE_HEIGHT = 60  # 节点基础高度 (标题 + 少量内边距)
@@ -33,6 +34,12 @@ def get_lineage_json_from_parsed_output(
         dict: 包含 'edges' 和 'nodes' 列表的字典。
     """
     try:
+        # 自动检测反引号并设置合适的SQL方言
+        detected_dialect = detect_and_set_dialect_for_backticks(sql_query, sql_dialect)
+        if detected_dialect != sql_dialect:
+            print(f"Auto-detected dialect '{detected_dialect}' due to backtick usage in SQL")
+            sql_dialect = detected_dialect
+
         # 修改：为每个SQL语句分别处理源表和目标表
         statements = sql_query.strip().split(';\n')
         statements = [stmt.strip() for stmt in statements if stmt.strip()]

--- a/api/sql_utils.py
+++ b/api/sql_utils.py
@@ -1,0 +1,72 @@
+import re
+from typing import Tuple, Optional
+
+
+def detect_and_set_dialect_for_backticks(sql_query: str, sql_dialect: str = 'default') -> str:
+    """
+    Detect backticks in SQL query and automatically set MySQL dialect if needed.
+
+    This function checks if the SQL query contains backtick-enclosed identifiers
+    and if so, ensures that the MySQL dialect is used for proper parsing.
+
+    Args:
+        sql_query (str): The original SQL query
+        sql_dialect (str): The SQL dialect ('mysql', 'postgresql', 'default', etc.)
+
+    Returns:
+        str: The appropriate SQL dialect to use
+    """
+    if sql_dialect != 'default':
+        # If user explicitly specified a dialect, use it as-is
+        return sql_dialect
+
+    # Check if query contains backticks (but not inside string literals)
+    has_backticks = False
+    in_single_quote = False
+    in_double_quote = False
+
+    for char in sql_query:
+        if char == "'" and not in_double_quote:
+            in_single_quote = not in_single_quote
+        elif char == '"' and not in_single_quote:
+            in_double_quote = not in_double_quote
+        elif char == '`' and not in_single_quote and not in_double_quote:
+            has_backticks = True
+            break
+
+    if has_backticks:
+        # Auto-detect MySQL dialect when backticks are present
+        return 'mysql'
+
+    return sql_dialect
+
+
+def test_backtick_preprocessing():
+    """Test function for backtick preprocessing."""
+    test_cases = [
+        # MySQL cases
+        ("SELECT `name` FROM `users`", "mysql"),
+        ("SELECT `user`.`name` FROM `user` WHERE `user`.`id` = 1", "mysql"),
+        ("INSERT INTO `orders` (`id`, `customer_id`) VALUES (1, 2)", "mysql"),
+        ("CREATE TABLE `test_table` (`id` INT, `name` VARCHAR(255))", "mysql"),
+
+        # Non-MySQL cases
+        ("SELECT `name` FROM `users`", "postgresql"),
+        ("SELECT `user`.`name` FROM `user`", "default"),
+
+        # Edge cases
+        ("SELECT 'hello `world`' as `message`", "mysql"),  # backtick in string literal
+        ("SELECT \"hello `world`\" as `message`", "mysql"),  # backtick in double quoted string
+        ("SELECT `column with spaces` FROM `table name`", "mysql"),
+    ]
+
+    for sql, dialect in test_cases:
+        processed, changed = preprocess_sql_backticks(sql, dialect)
+        print(f"Original ({dialect}): {sql}")
+        print(f"Processed: {processed}")
+        print(f"Changed: {changed}")
+        print("-" * 50)
+
+
+if __name__ == "__main__":
+    test_backtick_preprocessing()

--- a/api/table_lineage.py
+++ b/api/table_lineage.py
@@ -1,6 +1,7 @@
 from typing import Dict, List, Set, Union
 from sqllineage.runner import LineageRunner
 import traceback
+from sql_utils import detect_and_set_dialect_for_backticks
 
 # --- 布局常量 ---
 NODE_BASE_HEIGHT = 60  # 节点基础高度
@@ -26,6 +27,12 @@ def get_table_lineage_json(
         dict: 包含 'edges' 和 'nodes' 列表的字典
     """
     try:
+        # 自动检测反引号并设置合适的SQL方言
+        detected_dialect = detect_and_set_dialect_for_backticks(sql_query, sql_dialect)
+        if detected_dialect != sql_dialect:
+            print(f"Auto-detected dialect '{detected_dialect}' due to backtick usage in SQL")
+            sql_dialect = detected_dialect
+
         # 分割多个SQL语句
         statements = sql_query.strip().split(';\n')
         statements = [stmt.strip() for stmt in statements if stmt.strip()]


### PR DESCRIPTION
- 新增 sql_utils.py 工具模块，用于自动检测SQL中的反引号并设置合适的方言
- 在列级和表级血缘分析函数中集成方言自动检测功能
- 当SQL查询包含反引号且方言为'default'时，自动切换到'mysql'方言
- 保留用户显式指定的方言设置，确保向后兼容性
- 提高SQL解析准确率，支持MySQL风格的反引号标识符